### PR TITLE
Replace scala examples

### DIFF
--- a/site/src/site/html/index.html
+++ b/site/src/site/html/index.html
@@ -26,7 +26,7 @@
 
                 <p>
                     Suited for (but not limited to) installing Java related development kits. Install Groovy,
-                    Scala, Grails, Play or Spring Boot all from one convenient place. JDKs coming too!
+                    Gradle, Grails, Play or Spring Boot all from one convenient place. JDKs and Scala coming too!
                 </p>
             </article>
             <article>

--- a/site/src/site/pages/usage/current.groovy
+++ b/site/src/site/pages/usage/current.groovy
@@ -13,8 +13,8 @@ $ sdk current grails
         pre { code '''
 $ sdk current
   Using:
-  groovy: 2.1.0
-  scala: 2.11.7
+  gradle: 2.7
+  groovy: 2.4.5
 '''     }
 
     }

--- a/site/src/site/pages/usage/default.groovy
+++ b/site/src/site/pages/usage/default.groovy
@@ -2,9 +2,9 @@ article {
     a(name: 'default'){}
     h2 { yield 'Default Version' }
     p {
-        yield 'Chose to make a given version the default:'
         pre { code '$ sdk default scala 2.11.6' }
         yield 'This will ensure that all subsequent shells will start with version 2.11.6 in use.'
+        yield 'Choose to make a given version the default:'
     }
 }
 br()

--- a/site/src/site/pages/usage/default.groovy
+++ b/site/src/site/pages/usage/default.groovy
@@ -2,9 +2,9 @@ article {
     a(name: 'default'){}
     h2 { yield 'Default Version' }
     p {
-        pre { code '$ sdk default scala 2.11.6' }
-        yield 'This will ensure that all subsequent shells will start with version 2.11.6 in use.'
         yield 'Choose to make a given version the default:'
+        pre { code '$ sdk default groovy 2.3.9' }
+        yield 'This will ensure that all subsequent shells will start with version 2.3.9 in use.'
     }
 }
 br()

--- a/site/src/site/pages/usage/install.groovy
+++ b/site/src/site/pages/usage/install.groovy
@@ -37,7 +37,7 @@ Done installing!
         yield 'Need a '
         strong 'specific'
         yield ' version of an SDK? Simply qualify the version you require:'
-        pre { code '$ sdk install scala 2.11.7'  }
+        pre { code '$ sdk install groovy 2.4.5'  }
         yield 'All subsequent steps same as above.'
     }
 }

--- a/site/src/site/pages/usage/remove.groovy
+++ b/site/src/site/pages/usage/remove.groovy
@@ -3,7 +3,7 @@ article {
     h2 { yield 'Remove Version' }
     p {
         yield 'Remove an installed version.'
-        pre { code '$ sdk remove scala 2.11.6' }
+        pre { code '$ sdk remove groovy 2.4.5' }
     }
 }
 br()

--- a/site/src/site/pages/usage/use.groovy
+++ b/site/src/site/pages/usage/use.groovy
@@ -3,7 +3,7 @@ article {
     h2 { yield 'Use Version' }
     p {
         yield 'Choose to use a given version in the current terminal:'
-        pre { code '$ sdk use scala 2.11.6' }
+        pre { code '$ sdk use groovy 2.4.5' }
         yield 'It is important to realise that this will switch the candidate version '
         strong 'for the current shell only'
         yield '. To make this change permanent, use the '


### PR DESCRIPTION
Hello,

When first getting started with sdkman I found it really confusing that scala was listed but didn't work.  This PR replaces the scala examples with currently available packages (groovy/gradle), and updates the homepage to list Scala support as "coming soon" like the JDKs.

Thanks!
