### PR TITLE
Fix usage documentation for uninstalling

### DIFF
--- a/site/src/site/pages/usage/remove.groovy
+++ b/site/src/site/pages/usage/remove.groovy
@@ -3,7 +3,7 @@ article {
     h2 { yield 'Remove Version' }
     p {
         yield 'Remove an installed version.'
-        pre { code '$ sdk remove scala 2.11.6' }
+        pre { code '$ sdk uninstall scala 2.11.6' }
     }
 }
 br()


### PR DESCRIPTION
Documentation contained `remove` instead of `uninstall` or `rm`.