### PR TITLE
Generate Page with SKDs too (Candidates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 .gradle
 .classpath
 node_modules
+candidates.txt
+candidates.html

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -26,10 +26,46 @@ task copyCname(type:Copy) {
     into file("$buildDir/site")
 }
 
+task fetchCandidates(type:Copy) {
+    GFileUtils.copyURLToFile(new URL('https://api.sdkman.io/1/candidates/list'),new File('candidates.txt'));
+}
+
+task convertCandidates(type:Copy) {
+    dependsOn fetchCandidates
+
+    String s = GFileUtils.readFile(new File('candidates.txt'))
+    String gen = '';
+    // split the text for each candidate
+    def elements = s.split('----*\\n')
+
+    elements.eachWithIndex { String entry, int i ->
+        // ignore the 1st element. Candidates start at index 1
+        if(i > 0) {
+            def parts = entry.split('\\n\\n');
+
+            // title might have an url too
+            String title = parts[0];
+
+            // if the title has an url
+            String[] titleParts = title.split("(?=http\\:\\/\\/)|(?=https\\:\\/\\/)")
+            if(titleParts.size() > 1) {
+                gen+="<h4>"+titleParts[0]?.trim()+"</h4>\n"
+                gen+="<a href='"+titleParts[1]?.trim()+"' target='_blank'>"+titleParts[1]+"</a></br>\n"
+            } else {
+                gen += "<h4>" + title?.trim() + "</h4>\n" // title fallback
+            }
+            gen+="<p>"+parts[1]+"</p>\n" // content
+            gen+="<code>"+parts[2].trim()+"</code>\n" // footer
+            gen+="<hr/>\n"
+        }
+    }
+    GFileUtils.writeStringToFile(new File('./site/src/site/html/candidates.html'),gen)
+}
+
 task generateSite(type:JavaExec) {
 
     description = 'Generates the Groovy Website'
-    dependsOn copyAssets, copyCname
+    dependsOn copyAssets, copyCname, convertCandidates
 
     ext.sources = file('src/site')
     ext.outputDir = file("$buildDir/site")

--- a/site/src/site/pages/sdks.groovy
+++ b/site/src/site/pages/sdks.groovy
@@ -1,0 +1,14 @@
+layout 'layouts/main.groovy', true,
+        pageTitle: 'SDKs that SDKMAN! can install.',
+        mainContent: contents {
+            div(id: 'content') {
+                div(class: 'row') {
+                    div(class: 'col-lg-10') {
+                        h3('SDKs that SDKMAN! can install:')
+                        //pre(id: 'unique') {
+                            include unescaped: 'html/candidates.html'
+                        //}
+                    }
+                }
+            }
+        }

--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -1,6 +1,7 @@
 menu {
     group('sdkman') {
         item 'Install',                     'install.html'
+        item 'SDKs',                        'sdks.html'
         item 'Usage',                       'usage.html'
 //        item 'API',                         'api.html'
         item 'Vendors',                     'vendors.html'
@@ -19,6 +20,7 @@ menu {
 pages {
     page 'index', 'index'
     page 'install', 'install'
+    page 'sdks', 'sdks'
     page 'usage', 'usage'
 //    page 'api', 'api'
     page 'vendors', 'vendors'


### PR DESCRIPTION
Quick and dirty solution that generates a ```sdks.html``` page with the candidates fetched from legacy API and includes it in the menu too. (until the API can respond with JSON or HTML or some other format that does not require a fragile parsing).

See https://github.com/sdkman/sdkman-cli/issues/489  and https://github.com/sdkman/sdkman-website/issues/6