### PR TITLE
Rename "outdated" to "upgrade" in the docs

### DIFF
--- a/site/src/site/includes/usage-navbar.groovy
+++ b/site/src/site/includes/usage-navbar.groovy
@@ -9,7 +9,7 @@ ul(class: 'nav-sidebar') {
     li { a(href: '#use', class: 'anchor-link', 'Use Version') }
     li { a(href: '#default', class: 'anchor-link', 'Default Version') }
     li { a(href: '#current', class: 'anchor-link', 'Current Version') }
-    li { a(href: '#outdated', class: 'anchor-link', 'Outdated Version') }
+    li { a(href: '#upgrade', class: 'anchor-link', 'Upgrade Version') }
     li { a(href: '#version', class: 'anchor-link', 'Version') }
     li { a(href: '#broadcast', class: 'anchor-link', 'Broadcast Messages') }
     li { a(href: '#offline', class: 'anchor-link', 'Offline Mode') }

--- a/site/src/site/pages/usage.groovy
+++ b/site/src/site/pages/usage.groovy
@@ -22,7 +22,7 @@ layout 'layouts/main.groovy', true,
                             include template: 'pages/usage/use.groovy'
                             include template: 'pages/usage/default.groovy'
                             include template: 'pages/usage/current.groovy'
-                            include template: 'pages/usage/outdated.groovy'
+                            include template: 'pages/usage/upgrade.groovy'
                             include template: 'pages/usage/version.groovy'
                             include template: 'pages/usage/broadcast.groovy'
                             include template: 'pages/usage/offline.groovy'

--- a/site/src/site/pages/usage/help.groovy
+++ b/site/src/site/pages/usage/help.groovy
@@ -17,7 +17,7 @@ Usage: sdk <command> <candidate> [version]
        use       or u    <candidate> [version]
        default   or d    <candidate> [version]
        current   or c    [candidate]
-       outdated  or o    [candidate]
+       upgrade   or ug   [candidate]
        version   or v
        broadcast or b
        help      or h

--- a/site/src/site/pages/usage/upgrade.groovy
+++ b/site/src/site/pages/usage/upgrade.groovy
@@ -1,19 +1,19 @@
 article {
-    a(name: 'outdated'){}
-    h2 { yield 'Outdated Version(s)' }
+    a(name: 'upgrade'){}
+    h2 { yield 'Upgrade Version(s)' }
     p {
         yield 'To see what is currently out of date for a Candidate on your system:'
         pre { code '''
-$ sdk outdated springboot
-  Outdated:
+$ sdk upgrade springboot
+  Upgrade:
   springboot (1.2.4.RELEASE, 1.2.3.RELEASE < 1.2.5.RELEASE)
 '''     }
         yield 'To see what is outdated for '
         strong 'all'
         yield ' Candidates:'
         pre { code '''
-$ sdk outdated
-  Outdated:
+$ sdk upgrade
+  Upgrade:
   gradle (2.3, 1.11, 2.4, 2.5 < 2.6)
   grails (2.5.1 < 3.0.4)
   springboot (1.2.4.RELEASE, 1.2.3.RELEASE < 1.2.5.RELEASE)


### PR DESCRIPTION
The `outdated` command has been renamed to `upgrade` in sdkman-cli.

This PR makes the website reflect this change.