### PR TITLE
Update navigation to reflect changed commands

### DIFF
--- a/src/main/twirl/usage.scala.html
+++ b/src/main/twirl/usage.scala.html
@@ -16,7 +16,7 @@
                     <li><a href='#use' class='anchor-link'>Use Version</a></li>
                     <li><a href='#default' class='anchor-link'>Default Version</a></li>
                     <li><a href='#current' class='anchor-link'>Current Version</a></li>
-                    <li><a href='#outdated' class='anchor-link'>Outdated Version</a></li>
+                    <li><a href='#upgrade' class='anchor-link'>Upgrade Versions</a></li>
                     <li><a href='#version' class='anchor-link'>Version</a></li>
                     <li><a href='#broadcast' class='anchor-link'>Broadcast Messages</a></li>
                     <li><a href='#offline' class='anchor-link'>Offline Mode</a></li>


### PR DESCRIPTION
Command `outdated` is now called `upgrade`; the navigation has been pointing to nirvana.