### PR TITLE
Fixes sdkman_auto_env configuration type

### DIFF
--- a/app/views/usage.scala.html
+++ b/app/views/usage.scala.html
@@ -455,7 +455,7 @@ sdkman_debug_mode=true|false
 sdkman_colour_enable=true|false
 
 # enable automatic env
-sdkman_auto_env=true=true|false
+sdkman_auto_env=true|false
 </code> </pre>
                     </p>
                 </article>


### PR DESCRIPTION
removes double true  `sdkman_auto_env=true=true|false`