### PR TITLE
Fix #51: Add Microsoft to JDKs page

### DIFF
--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -71,6 +71,20 @@ jdks {
     """
     },
     {
+      id = "ms"
+      vendor = "Microsoft"
+      distribution = "OpenJDK"
+      url = "https://www.microsoft.com/openjdk"
+      description = """
+    The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's
+    open source and available for free for anyone to deploy anywhere. It
+    includes Long-Term Support (LTS) binaries for Java 11 on x64 server and
+    desktop environments on macOS, Linux, and Windows, and AArch64/ARM64 on
+    Linux and Windows. Microsoft also publishes Java 16 binaries for all three
+    major Operating Systems and both x64 and AArch64 (M1/ARM64) architectures.
+    """
+    },
+    {
       id = "sapmchn"
       vendor = "SAP"
       distribution = "SapMachine"


### PR DESCRIPTION
 - Content pulled from https://docs.microsoft.com/en-us/java/openjdk/overview