### PR TITLE
Update JDKs page

### DIFF
--- a/app/controllers/ContextualController.scala
+++ b/app/controllers/ContextualController.scala
@@ -33,7 +33,7 @@ class ContextualController @Inject()(cc: ControllerComponents,
   }
 
   def jdks = Action.async { _ =>
-    Future.successful(Ok(views.html.jdks(conf.as[Seq[Jdk]]("jdks.vendors"))))
+    Future.successful(Ok(views.html.jdks(conf.as[Seq[Jdk]]("jdks.vendors").sortBy(_.distribution))))
   }
 
   def sdks = Action.async { _ =>

--- a/app/controllers/ContextualController.scala
+++ b/app/controllers/ContextualController.scala
@@ -33,8 +33,7 @@ class ContextualController @Inject()(cc: ControllerComponents,
   }
 
   def jdks = Action.async { _ =>
-    val jdkVendors = conf.as[Seq[Jdk]]("jdks.vendors")
-    Future.successful(Ok(views.html.jdks(jdkVendors)))
+    Future.successful(Ok(views.html.jdks(conf.as[Seq[Jdk]]("jdks.vendors"))))
   }
 
   def sdks = Action.async { _ =>

--- a/app/views/jdks.scala.html
+++ b/app/views/jdks.scala.html
@@ -6,8 +6,8 @@
             <div class='col-lg-3'>
                 <ul class='nav-sidebar'>
                     <li class='active'><a href='/jdks'><strong>Available JDKs</strong></a></li>
-                    @for(j <- jdks) {
-                    <li><a href='#@{j.vendor}' class='anchor-link'>@{j.distribution}: <em>@{j.vendor}</em></a></li>
+                    @for(jdk <- jdks) {
+                    <li><a href='#@{jdk.id}' class='anchor-link'>@{jdk.distribution} - <em>@{jdk.vendor}</em></a></li>
                     }
                 </ul>
             </div>
@@ -16,10 +16,9 @@
                 @includes.advertisement()
                 <ul>
                     @for(jdk <- jdks) {
-                    <a name='@jdk.vendor'></a>
+                    <a name='@jdk.id'></a>
                     <li>
-                        <h4>@jdk.distribution</h4>
-                        <a href='@jdk.url' target='_blank'><h5>@jdk.vendor</h5></a>
+                        <h4><a href='@jdk.url' target='_blank'>@jdk.distribution</a> (@jdk.vendor)</h4>
                         <p>@jdk.description</p>
                         <code>$ sdk install java x.y.z-@jdk.id</code>
                         <hr/>

--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -43,6 +43,20 @@ jdks {
     """
     },
     {
+      id = "oracle"
+      vendor = "Oracle"
+      distribution = "Java SE Development Kit"
+      url = "https://www.oracle.com/java/"
+      description = """
+        This proprietary Java Development Kit is an implementation of the Java Platform,
+        Standard Edition released by Oracle Corporation in the form of a binary
+        product aimed at Java developers on Linux, macOS or Windows. The JDK
+        includes a private JVM and a few other resources to finish the development
+        of a Java application. It is distributed under the Oracle No-Fee Terms and
+        Conditions License
+    """
+    },
+    {
       id = "librca"
       vendor = "Bellsoft"
       distribution = "Liberica"

--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -6,14 +6,27 @@ jdks {
       distribution = "Corretto"
       url = "https://aws.amazon.com/corretto/"
       description = """
-    Amazon Corretto is a no-cost, multiplatform, production-ready distribution
-    of the Open Java Development Kit (OpenJDK). Corretto comes with long-term
-    support that will include performance enhancements and security fixes.
-    Amazon runs Corretto internally on thousands of production services and
-    Corretto is certified as compatible with the Java SE standard. With
-    Corretto, you can develop and run Java applications on popular operating
-    systems, including Linux, Windows, and macOS.
+        Amazon Corretto is a no-cost, multiplatform, production-ready distribution
+        of the Open Java Development Kit (OpenJDK). Corretto comes with long-term
+        support that will include performance enhancements and security fixes.
+        Amazon runs Corretto internally on thousands of production services and
+        Corretto is certified as compatible with the Java SE standard. With
+        Corretto, you can develop and run Java applications on popular operating
+        systems, including Linux, Windows, and macOS.
     """
+    },
+    {
+      id = "albba",
+      vendor = "Alibaba",
+      distribution = "Dragonwell",
+      url = "http://dragonwell-jdk.io",
+      description = """
+        Dragonwell, as a downstream version of OpenJDK, is the in-house
+        OpenJDK implementation at Alibaba. It is optimized for online e-commerce,
+        financial and logistics applications running on 100,000+ servers. Alibaba
+        Dragonwell is the engine that runs these distributed Java applications in
+        extreme scaling.
+      """
     },
     {
       id = "grl"
@@ -21,12 +34,12 @@ jdks {
       distribution = "GraalVM"
       url = "https://www.graalvm.org/"
       description = """
-    GraalVM is a universal virtual machine for running applications written in
-    JavaScript, Python, Ruby, R, JVM-based languages like Java, Scala, Groovy,
-    Kotlin, Clojure, and LLVM-based languages such as C and C++. GraalVM
-    removes the isolation between programming languages and enables
-    interoperability in a shared runtime. It can run either standalone or in
-    the context of OpenJDK, Node.js or Oracle Database.
+        GraalVM is a universal virtual machine for running applications written in
+        JavaScript, Python, Ruby, R, JVM-based languages like Java, Scala, Groovy,
+        Kotlin, Clojure, and LLVM-based languages such as C and C++. GraalVM
+        removes the isolation between programming languages and enables
+        interoperability in a shared runtime. It can run either standalone or in
+        the context of OpenJDK, Node.js or Oracle Database.
     """
     },
     {
@@ -35,23 +48,37 @@ jdks {
       distribution = "Liberica"
       url = "https://bell-sw.com/"
       description = """
-    Liberica is a 100% open-source Java implementation. It is built from
-    OpenJDK which BellSoft contributes to, is thoroughly tested and passed the
-    JCK provided under the license from OpenJDK. All supported versions of
-    Liberica also contain JavaFX 12.
+        Liberica is a 100% open-source Java implementation. It is built from
+        OpenJDK which BellSoft contributes to, is thoroughly tested and passed the
+        JCK provided under the license from OpenJDK. All supported versions of
+        Liberica also contain JavaFX.
     """
     },
     {
-      id = "adpt"
-      vendor = "AdoptOpenJDK"
-      distribution = "OpenJDK"
-      url = "https://adoptopenjdk.net/"
+      id = "nik"
+      vendor = "Bellsoft"
+      distribution = "Liberica NIK"
+      url = "https://bell-sw.com/pages/liberica-native-image-kit"
       description = """
-    AdoptOpenJDK.net started in 2017 following years of discussions about the
-    general lack of an open and reproducible build and test system for OpenJDK
-    source across multiple platforms. AdoptOpenJDK provides rock-solid OpenJDK
-    binaries for the Java ecosystem and also provides infrastructure as code,
-    and a Build farm for builders of OpenJDK, on any platform.
+        Liberica Native Image Kit is a utility that converts your JVM-based application
+        into a fully compiled native executable ahead-of-time under the closed-world
+        assumption with an almost instant startup time. Being compatible with various
+        platforms, including lightweight musl-based Alpine Linux, it optimizes resource
+        consumption and minimizes the static footprint.
+    """
+    },
+    {
+      id = "mandrel"
+      vendor = "Red Hat"
+      distribution = "Mandrel"
+      url = "https://github.com/graalvm/mandrel"
+      description = """
+        Mandrel focuses on GraalVM's native-image component in order to provide
+        an easy way for Quarkus users to generate native images for their
+        applications. Developers using Quarkus should be able to go all the way
+        from Java source code to lean, native, platform-dependent applications
+        running on Linux. This capability is vital for deploying to containers
+        in a cloud-native application development model.
     """
     },
     {
@@ -60,14 +87,14 @@ jdks {
       distribution = "OpenJDK"
       url = "https://jdk.java.net/"
       description = """
-    OpenJDK (Open Java Development Kit) is a free and open-source
-    implementation of the Java Platform, Standard Edition (Java SE). It is the
-    result of an effort Sun Microsystems began in 2006. The implementation is
-    licensed under the GNU General Public License (GNU GPL) version 2 with a
-    linking exception. Were it not for the GPL linking exception, components
-    that linked to the Java class library would be subject to the terms of the
-    GPL license. OpenJDK is the official reference implementation of Java SE
-    since version 7.
+        OpenJDK (Open Java Development Kit) is a free and open-source
+        implementation of the Java Platform, Standard Edition (Java SE). It is the
+        result of an effort Sun Microsystems began in 2006. The implementation is
+        licensed under the GNU General Public License (GNU GPL) version 2 with a
+        linking exception. Were it not for the GPL linking exception, components
+        that linked to the Java class library would be subject to the terms of the
+        GPL license. OpenJDK is the official reference implementation of Java SE
+        since version 7.
     """
     },
     {
@@ -76,12 +103,12 @@ jdks {
       distribution = "OpenJDK"
       url = "https://www.microsoft.com/openjdk"
       description = """
-    The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's
-    open source and available for free for anyone to deploy anywhere. It
-    includes Long-Term Support (LTS) binaries for Java 11 on x64 server and
-    desktop environments on macOS, Linux, and Windows, and AArch64/ARM64 on
-    Linux and Windows. Microsoft also publishes Java 16 binaries for all three
-    major Operating Systems and both x64 and AArch64 (M1/ARM64) architectures.
+        The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's
+        open source and available for free for anyone to deploy anywhere. It
+        includes Long-Term Support (LTS) binaries for Java 11 on x64 server and
+        desktop environments on macOS, Linux, and Windows, and AArch64/ARM64 on
+        Linux and Windows. Microsoft also publishes Java 16 binaries for all three
+        major Operating Systems and both x64 and AArch64 (M1/ARM64) architectures.
     """
     },
     {
@@ -90,15 +117,48 @@ jdks {
       distribution = "SapMachine"
       url = "https://sap.github.io/SapMachine/"
       description = """
-    SAP SE is a German multinational software corporation that makes enterprise
-    software to manage business operations and customer relations. SAP is
-    headquartered in Walldorf, Baden-Württemberg, Germany with regional offices
-    in 180 countries. SapMachine is a downstream version of the OpenJDK
-    project. It is used to build and maintain a SAP supported version of
-    OpenJDK for SAP customers and partners who wish to use OpenJDK to run their
-    applications. SAP is committed to ensuring the continued success of the
-    Java platform.
+        SapMachine is a downstream version of the OpenJDK
+        project. It is used to build and maintain a SAP supported version of
+        OpenJDK for SAP customers and partners who wish to use OpenJDK to run their
+        applications. SAP is committed to ensuring the continued success of the
+        Java platform.
     """
+    },
+    {
+      id = "sem",
+      vendor = "IBM",
+      distribution = "Semeru",
+      url = "https://developer.ibm.com/languages/java/semeru-runtimes/",
+      description = """
+        Semeru Runtimes use the class libraries from OpenJDK, along with
+        the Eclipse OpenJ9 Java Virtual Machine to enable developers to build
+        and deploy Java applications that will start quickly, deliver great
+        performance, all while using less memory.
+      """
+    },
+    {
+      id = "tem",
+      vendor = "Eclipse",
+      distribution = "Temurin",
+      url = "https://projects.eclipse.org/projects/adoptium.temurin",
+      description = """
+        Formerly AdoptOpenJDK, the Eclipse Adoptium Temurin™ project provides
+        code and processes that support the building of runtime binaries and
+        associated technologies that are high performance, enterprise-caliber,
+        cross-platform, open-source licensed, and Java SE TCK-tested for general
+        use across the Java ecosystem.
+      """
+    },
+    {
+      id = "trava",
+      vendor = "Trava",
+      distribution = "Trava",
+      url = "https://github.com/TravaOpenJDK/trava-jdk-11-dcevm",
+      description = """
+        TravaOpenJDK is OpenJDK for developers. It is based on dcevm
+        and uses an integrated HotswapAgent, so allowing advanced hotswapping of
+        classes by method and field addition or updates at runtime.
+      """
     },
     {
       id = "zulu"
@@ -106,12 +166,9 @@ jdks {
       distribution = "Zulu"
       url = "https://www.azul.com/downloads/zulu/"
       description = """
-    Azul Systems serves companies who need to deliver server-based Java
-    applications for their web-facing customers (travel, online retail, gaming,
-    SaaS), meet specific latency targets for real-time business systems
-    (advertising networks, capital markets, communications) ensure timely
-    maintenance or security updates for essential applications, or deliver
-    Java-based systems for embedded and IoT use cases.
+        Azul Zulu is an open source implementation of the Java Standard Edition ("SE")
+        specification. It is a binary build of the OpenJDK open source project. Zulu
+        provides a Java Runtime Environment needed for Java applications to run.
     """
     },
   ]


### PR DESCRIPTION
Remove AdoptOpenJDK and adds Oracle Java SE JDK, Temurin and Semeru. It also cleans up some formatting, improves the copy and automatically sorts by distribution.