### PR TITLE
Move getting started section to center of page. Replaces old section with open source blurb.

### DIFF
--- a/app/views/includes/footer.scala.html
+++ b/app/views/includes/footer.scala.html
@@ -3,7 +3,7 @@
 <footer id='footer'>
     <div class='row'>
         <div class='clearfix'>&copy; 2012 - @DateTimeFormatter.ofPattern("YYYY").format(LocalDate.now) SDKMAN! is Open Source Software licensed under <a
-                href='http://www.apache.org/licenses/LICENSE-2.0.html'>Apache 2</a></div>
+                href='http://www.apache.org/licenses/LICENSE-2.0.html'>Apache 2.0</a></div>
         <div class='clearfix'>Logos and additional Design by <a href='https://github.com/dmesu'>Daida
             Medina</a></div>
     </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -10,7 +10,7 @@
             Go on, paste and run the following in a terminal:
             <br>
             <code>
-            $ curl -s "https://get.sdkman.io" | bash
+            curl -s "https://get.sdkman.io" | bash
             </code>
         </p>
 

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -4,6 +4,16 @@
 <div id='band' class='band'></div>
 <div id='content'>
     <section class="row colset-2-its">
+        <h1>Get started now!</h1>
+
+        <p>
+            Go on, paste and run the following in a terminal:
+            <br>
+            <code>
+            $ curl -s "https://get.sdkman.io" | bash
+            </code>
+        </p>
+
         <h1>The Software Development Kit Manager</h1>
 
         <p id="main-paragraph">
@@ -74,19 +84,16 @@
             </article>
             <article>
                 <div class="icon icon-3"></div>
-                <h1>Get started now!</h1>
+                <h1>Open Source</h1>
 
                 <p>
-                    Go on, paste and run the following in a terminal:
+                    Backed by a wonderful community of developers from around the world.
                     <br>
-                    <code>
-                        $ curl -s "https://get.sdkman.io" | bash
-                    </code>
+                    Licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>
                 </p>
             </article>
         </div>
     </section>
-
     @includes.opencollective()
 
     <div class="nested-wrapper">

--- a/app/views/install.scala.html
+++ b/app/views/install.scala.html
@@ -11,15 +11,15 @@
                     SDKMAN! installs smoothly on macOS, Linux, WSL, Cygwin,
                     Solaris and FreeBSD. We also support Bash and ZSH shells.<br/>Simply open a new
                     terminal and enter: </p>
-                    <pre><code>$ curl -s "https://get.sdkman.io" | bash</code></pre>
+                    <pre><code>curl -s "https://get.sdkman.io" | bash</code></pre>
                     <p>Follow the instructions on-screen to complete installation.<br/>Next, open a
                         new terminal <b>or</b> enter:</p>
-                    <pre><code>$ source "$HOME/.sdkman/bin/sdkman-init.sh"</code></pre>
+                    <pre><code>source "$HOME/.sdkman/bin/sdkman-init.sh"</code></pre>
                     <p>Lastly, run the following code snippet to ensure that installation
                         succeeded:</p>
-                    <pre><code>$ sdk version</code></pre>
+                    <pre><code>sdk version</code></pre>
                     <p>If all went well, the version should be displayed. Something like:</p>
-                    <pre><code>  sdkman 5.0.0+51</code></pre>
+                    <pre><code>sdkman 5.0.0+51</code></pre>
                 </article>
                 <article><h3>Windows Installation</h3>
                     <p>Several options exist for installing SDKMAN! on Windows today.</p>
@@ -43,12 +43,12 @@
                         Beta versions can be considered stable for the most part, but might
                         occasionally break.
                         To join the beta channel, you can install it directly as follows:
-                        <pre><code>$ curl -s "https://beta.sdkman.io" | bash</code></pre>
+                        <pre><code>curl -s "https://beta.sdkman.io" | bash</code></pre>
                         If you already have the stable version installed, simply update the
                         <code>~/.sdkman/etc/config</code> file as follows:
                     <pre><code>sdkman_beta_channel=true</code></pre>
                     Next, open a new terminal and perform a forced update with:
-                    <pre><code>$ sdk selfupdate force</code></pre>
+                    <pre><code>sdk selfupdate force</code></pre>
                     To leave the beta channel, simply set the above config back to
                     <code>false</code> and follow the same procedure.</p></article>
                 <article><h3>Uninstallation</h3>In the unlikely event that you would like to
@@ -56,23 +56,19 @@
                     an automated way of doing this yet. If you really do want to remove it from your
                     system, it is very easy to do so.The following will guide you through backing
                     up, then removing the entire installation from your system.
-                    <pre><code>
-tar zcvf ~/sdkman-backup_$(date +%F-%kh%M).tar.gz -C ~/ .sdkman
-$ rm -rf ~/.sdkman</code></pre>
+		    <pre><code>tar zcvf ~/sdkman-backup_$(date +%F-%kh%M).tar.gz -C ~/ .sdkman</code><br><code>rm -rf ~/.sdkman</code></pre>
                     The last step involves editing and removing the initialisation snippet from your
                     <code>.bashrc</code>, <code>.bash_profile</code> and/or <code>.profile</code>
                     files. If you use ZSH, remove it from the <code>.zshrc</code> file. The snippet
                     of code to be removed looks something like this:
-                    <pre><code>
-#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
-[[ -s "/home/dudette/.sdkman/bin/sdkman-init.sh" ]] && source "/home/dudette/.sdkman/bin/sdkman-init.sh"</code></pre>
+                    <pre>#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!<br>[[ -s "/home/dudette/.sdkman/bin/sdkman-init.sh" ]] && source "/home/dudette/.sdkman/bin/sdkman-init.sh"</pre>
                     Once removed, you have successfully uninstalled SDKMAN! from your machine.
                 </article>
                 <article><h3>Installing to a Custom Location</h3>It is possible to install SDKMAN!
                     to a custom location other than <code>$HOME/.sdkman</code>. This can be achieved
                     by exporting your custom location as <code>SDKMAN_DIR</code> prior to
                     installing.<br/>Simply open a new terminal and enter:
-                    <pre><code>$ export SDKMAN_DIR="/usr/local/sdkman" && curl -s "https://get.sdkman.io" | bash</code></pre>
+                    <pre><code>export SDKMAN_DIR="/usr/local/sdkman" && curl -s "https://get.sdkman.io" | bash</code></pre>
                     For this to work it is vital that your user has full access rights to this
                     folder.It is also important that the folder does not exist as SDKMAN! will
                     attempt to create it.
@@ -82,7 +78,7 @@ $ rm -rf ~/.sdkman</code></pre>
                     such as unattended installs or when reinstalling.  In those situations, appending
                     <code>rcupdate=false</code> as a parameter when downloading the installer will cause
                     it to skip that portion of the installation process.
-                    <pre><code>$ curl -s "https://get.sdkman.io?rcupdate=false" | bash</code></pre>
+                    <pre><code>curl -s "https://get.sdkman.io?rcupdate=false" | bash</code></pre>
                 </article>
                 <p>That&apos;s all there is to it! Next we will look at <a href='/usage'>Usage</a>.
                 </p></div>

--- a/app/views/jdks.scala.html
+++ b/app/views/jdks.scala.html
@@ -20,7 +20,7 @@
                     <li>
                         <h4><a href='@jdk.url' target='_blank'>@jdk.distribution</a> (@jdk.vendor)</h4>
                         <p>@jdk.description</p>
-                        <code>$ sdk install java x.y.z-@jdk.id</code>
+                        <code>sdk install java x.y.z-@jdk.id</code>
                         <hr/>
                     </li>
                     }

--- a/app/views/sdks.scala.html
+++ b/app/views/sdks.scala.html
@@ -22,7 +22,7 @@
                         <h4>@c.name (@c.default.getOrElse("Coming soon!"))</h4>
                         <a href='@c.websiteUrl' target='_blank'>@c.websiteUrl</a></br>
                         <p>@c.description</p>
-                        <code>$ sdk install @c.candidate</code>
+                        <code>sdk install @c.candidate</code>
                         <hr/>
                     </li>
                     }

--- a/app/views/usage.scala.html
+++ b/app/views/usage.scala.html
@@ -38,7 +38,7 @@
                     <p>
                         Install the <strong>latest stable</strong> version of your SDK of choice
                         (say, Java JDK) by running the following command:
-                    <pre><code>$ sdk install java</code></pre>
+                    <pre><code>sdk install java</code></pre>
                     You will see something like the following output:
                     <pre>
                                 <code>
@@ -62,13 +62,13 @@ Done installing!
                     <p>
                         Need a <strong>specific</strong> version of an SDK? Simply qualify the
                         version you require:
-                    <pre><code>$ sdk install scala 2.12.1</code></pre>
+                    <pre><code>sdk install scala 2.12.1</code></pre>
                     All subsequent steps same as above.
                     </p><a name='localversion'></a><h4>Install Local Version(s)</h4>
                     <p>
                         Using a snapshot version? Already have a local installation? Setup a local version by specifying the path to the local installation:
-                    <pre><code>$ sdk install groovy 3.0.0-SNAPSHOT /path/to/groovy-3.0.0-SNAPSHOT</code></pre>
-                    <pre><code>$ sdk install java 10-zulu /Library/Java/JavaVirtualMachines/zulu-10.jdk/Contents/Home</code></pre>
+                    <pre><code>sdk install groovy 3.0.0-SNAPSHOT /path/to/groovy-3.0.0-SNAPSHOT</code></pre>
+                    <pre><code>sdk install java 10-zulu /Library/Java/JavaVirtualMachines/zulu-10.jdk/Contents/Home</code></pre>
                     Note that the local version name (<em>3.0.0-SNAPSHOT</em> and
                     <em>10-zulu</em> in the examples above) must be a unique name
                     which is not already in the list of available version names.
@@ -80,7 +80,7 @@ Done installing!
                     <h2>Remove Version</h2>
                     <p>
                         Remove an installed version.
-                    <pre><code>$ sdk uninstall scala 2.11.6</code></pre>
+                    <pre><code>sdk uninstall scala 2.11.6</code></pre>
                     Note that removing a local version will not remove the local installation.
                     </p>
                 </article>
@@ -90,7 +90,7 @@ Done installing!
                     <h2>List Candidates</h2>
                     <p>
                         To get a listing of available Candidates:
-                    <pre><code>$ sdk list</code></pre>
+                    <pre><code>sdk list</code></pre>
                     This will render a searchable alphabetic list with name, current stable default
                     version, website URL, description and easy install command for each Candidate.
                     The output is piped to <code>less</code> so standard keyboard shortcuts may be
@@ -113,7 +113,7 @@ application powerful features, including scripting capabilities, Domain-Specific
 Language authoring, runtime and compile-time meta-programming and functional
 programming.
 
-                                        $ sdk install groovy
+                                                            $ sdk install groovy
 --------------------------------------------------------------------------------
 Scala (2.11.7)                                        http://www.scala-lang.org/
 ...
@@ -127,7 +127,7 @@ Scala (2.11.7)                                        http://www.scala-lang.org/
                     <h2>List Versions</h2>
                     <p>
                         To get a listing of Candidate Versions:
-                    <pre><code>$ sdk list groovy</code></pre>
+                    <pre><code>sdk list groovy</code></pre>
                     This will result in a list view showing the available, local, installed and
                     current versions of the SDK.
                     <pre><code>
@@ -165,7 +165,7 @@ Available Groovy Versions
                     <h2>Use Version</h2>
                     <p>
                         Choose to use a given version in the current terminal:
-                    <pre><code>$ sdk use scala 2.12.1</code></pre>
+                    <pre><code>sdk use scala 2.12.1</code></pre>
                     It is important to realise that this will switch the candidate version <strong>for
                     the current shell only</strong>. To make this change permanent, use the <a
                         href='#default'>default</a> command instead.
@@ -177,7 +177,7 @@ Available Groovy Versions
                     <h2>Default Version</h2>
                     <p>
                         Chose to make a given version the default:
-                    <pre><code>$ sdk default scala 2.11.6</code></pre>
+                    <pre><code>sdk default scala 2.11.6</code></pre>
                     This will ensure that all subsequent shells will start with version 2.11.6 in
                     use.
                     </p>
@@ -188,13 +188,9 @@ Available Groovy Versions
                     <h2>Current Version(s)</h2>
                     <p>
                         To see what is currently in use for a Candidate:
-                    <pre><code>
-$ sdk current java
-Using java version 8u111
-</code></pre>
+                    <pre><code>sdk current java<br>Using java version 8u111</code></pre>
                     To see what is currently in use for <strong>all</strong> Candidates:
-                    <pre><code>
-$ sdk current
+                    <pre><code>sdk current
 Using:
 groovy: 2.4.7
 java: 8u111
@@ -211,12 +207,12 @@ scala: 2.12.1
                     This can be achieved through an <code>.sdkmanrc</code> file in the base
                     directory of your project. This file can be generated automatically by
                     issuing the following command:
-                    <pre><code>$ sdk env init</code></pre>
+                    <pre><code>sdk env init</code></pre>
                     A config file with the following content has now been created in the
                     current directory:
-                    <pre><code># Enable auto-env through the sdkman_auto_env config
+                    <pre># Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=x.y.z.hs-adpt</code></pre>
+java=x.y.z.hs-adpt</pre>
                     The file is pre-populated with the current JDK version in use, but can
                     contain as may key-value pairs of supported SDKs as needed.
                     To switch to the configuration present in your <code>.sdkmanrc</code> file,
@@ -227,14 +223,10 @@ java=x.y.z.hs-adpt</code></pre>
                     Your path has now also been updated to use any of these SDKs in your current shell.
                     When leaving a project, you may want to reset the SDKs to their default version.
                     This can be achieved by entering:
-                    <pre><code>
-$ sdk env clear
-Restored java version to x.y.z.hs-adpt (default)
-                    </code></pre>
+                    <pre><code>sdk env clear<br>Restored java version to x.y.z.hs-adpt (default)</code></pre>
                     After checking out a new project, you may be missing some SDKs specified in the project's
                     <code>.sdkmanrc</code> file. To install these missings SDKs, just type:
-                    <pre><code>
-$ sdk env install
+                    <pre><code>sdk env install
 
 Downloading: java x.y.z.hs-adpt
 
@@ -262,14 +254,12 @@ Done installing!
                     <h2>Upgrade Version(s)</h2>
                     <p>
                         To see what is currently out of date for a Candidate on your system:
-                    <pre><code>
-$ sdk upgrade springboot
+                    <pre><code>sdk upgrade springboot
 Upgrade:
 springboot (1.2.4.RELEASE, 1.2.3.RELEASE < 1.2.5.RELEASE)
 </code></pre>
                     To see what is outdated for <strong>all</strong> Candidates:
-                    <pre><code>
-$ sdk upgrade
+                    <pre><code>sdk upgrade
 Upgrade:
 gradle (2.3, 1.11, 2.4, 2.5 < 2.6)
 grails (2.5.1 < 3.0.4)
@@ -283,7 +273,7 @@ springboot (1.2.4.RELEASE, 1.2.3.RELEASE < 1.2.5.RELEASE)
                     <h2>SDKMAN! Version</h2>
                     <p>
                         Display the current version of SDKMAN!:
-                    <pre><code>$ sdk version</code></pre>
+                    <pre><code>sdk version</code></pre>
                     </p>
                 </article>
                 <br/>
@@ -292,8 +282,7 @@ springboot (1.2.4.RELEASE, 1.2.3.RELEASE < 1.2.5.RELEASE)
                     <h2>Broadcast Messages</h2>
                     <p>
                         Get the latest SDK release notifications on the command line:
-                    <pre><code>
-$ sdk broadcast
+                    <pre><code>sdk broadcast
 ==== BROADCAST =================================================================
 * 06/12/16: Scala 2.12.1 released on SDKMAN! #scala
 * 23/11/16: Gradle 3.2.1 released on SDKMAN! #gradle
@@ -313,18 +302,16 @@ $ sdk broadcast
                         Initially called <em>Aeroplane Mode</em>, this allows SDKMAN! to function
                         when working offline. It has a parameter that can be passed
                         to<em>enable</em> or <em>disable</em> the offline mode.
-                    <pre><code>
-$ sdk offline enable
+                    <pre><code>sdk offline enable
 Forced offline mode enabled.
-
-$ sdk offline disable
+</code>
+<code>sdk offline disable
 Online mode re-enabled!
 </code></pre>
                     When operating in <strong>offline</strong> mode, most commands will still work
                     even though they will operate in a scaled down capacity. An example is the list
                     command, which will only display the currently installed and active version(s):
-                    <pre><code>
-$ sdk list groovy
+                    <pre><code>sdk list groovy
 ------------------------------------------------------------
 Offline Mode: only showing installed groovy versions
 ------------------------------------------------------------
@@ -346,10 +333,10 @@ Offline Mode: only showing installed groovy versions
                     <h2>Self-Update</h2>
                     <p>
                         Installs a new version of SDKMAN! if available.
-                    <pre><code>$ sdk selfupdate</code></pre>
+                    <pre><code>sdk selfupdate</code></pre>
                     If no new version is available an appropriate message will be displayed.
                     Re-installation may be forced by passing the force parameter to the command:
-                    <pre><code>$ sdk selfupdate force</code></pre>
+                    <pre><code>sdk selfupdate force</code></pre>
                     Automatic daily checks for new versions of SDKMAN! will also be performed on the
                     behalf of the user.
                     </p>
@@ -367,10 +354,9 @@ Offline Mode: only showing installed groovy versions
                         cache will be refreshed and new candidates will become available for
                         installation:
 
-                    <pre><code>
-WARNING: SDKMAN is out-of-date and requires an update.
-
-$ sdk update
+                    <pre>
+<code>WARNING: SDKMAN is out-of-date and requires an update.</code>
+<code>sdk update
 Adding new candidates(s): kotlin
                     </code></pre>
                     </p>
@@ -384,19 +370,19 @@ Adding new candidates(s): kotlin
                         state.The flush command helps with this and allows for the following to be
                         performed:
                     <h4>Flush storage</h4>
-                    <pre><code>$ sdk flush</code></pre>
+                    <pre><code>sdk flush</code></pre>
                     This flushes out all archives and the temporary storage folder, but not
                     the broadcast cache.
                     <h4>Broadcast</h4>
-                    <pre><code>$ sdk flush broadcast</code></pre>
+                    <pre><code>sdk flush broadcast</code></pre>
                     Clears out the broadcast cache, downloading the latest available news on next
                     command invocation.
                     <h4>Archives</h4>
-                    <pre><code>$ sdk flush archives</code></pre>
+                    <pre><code>sdk flush archives</code></pre>
                     Cleans the cache containing all downloaded SDK binaries. This can take up a lot
                     of space so is worth clearing out from time to time!
                     <h4>Temporary Folder</h4>
-                    <pre><code>$ sdk flush tmp</code></pre>
+                    <pre><code>sdk flush tmp</code></pre>
                     Clears out the staging work folder used when installing new versions of
                     candidates and SDKMAN! itself.
                     </p>
@@ -409,7 +395,7 @@ Adding new candidates(s): kotlin
                         When using SDKMAN in scripts, it is often useful to get the absolute
                         path of where an SDK resides (similar to how the <code>java_home</code>
                         command works on macOS). For this we have the <code>home</code> command.
-                        <pre><code>$ sdk home java 11.0.7.hs-adpt
+                        <pre><code>sdk home java 11.0.7.hs-adpt
 /home/somedude/.sdkman/candidates/java/11.0.7.hs-adpt</code></pre>
                     </p>
                 </article>
@@ -419,7 +405,7 @@ Adding new candidates(s): kotlin
                     <h2>Help</h2>
                     <p>
                         You can get basic help by running the following command:
-                    <pre><code>$ sdk help</code></pre>
+                    <pre><code>sdk help</code></pre>
                     This should yield something like:
                     <pre><code>
 Usage:  sdk &lt;command&gt; [candidate] [version]

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1327,3 +1327,7 @@ html, body, .st-container, .st-pusher, .st-content {
     list-style-type: none;
     padding-left: .2em
 }
+code::before {
+    display: inline;
+    content: '$ ';
+}


### PR DESCRIPTION
This is a follow up PR for #56. I was unfortunately unable to test these changes locally since the docker image does not run on Mac M1.  

@marc0der Please take a look.