### PR TITLE
Add Tencent Kona to JDKs page

### DIFF
--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -59,6 +59,18 @@ jdks {
     """
     },
     {
+      id = "kona"
+      vendor = "Tencent"
+      distribution = "Kona"
+      url = "https://github.com/Tencent/TencentKona-8"
+      description = """
+        Tencent Kona is a free, multi-platform, and production-ready distribution
+        of OpenJDK, featuring Long-Term Support (LTS) releases. It serves as the
+        default JDK within Tencent for cloud computing, big data, and numerous
+        other Java applications.
+      """
+    },
+    {
       id = "oracle"
       vendor = "Oracle"
       distribution = "Java SE Development Kit"


### PR DESCRIPTION
SDKMAN already supports Tencent Kona JDK, like the below,

```
% sdk list java | grep kona
Tencent       |     | 17.0.7       | kona    |            | 17.0.7-kona
              |     | 11.0.19      | kona    |            | 11.0.19-kona
              |     | 8.0.372      | kona    |            | 8.0.372-kona
```

But the below page doesn't list this JDK yet.
https://sdkman.io/jdks

This PR will resolve #67.