### PR TITLE
Add Huawei Bisheng to JDKs.

### DIFF
--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -35,7 +35,7 @@ jdks {
       url = "https://bishengjdk.openeuler.org/"
       description = """
         BiSheng JDK, an open-source adaptation of Huawei JDK derived from
-        OpenJDK, is utilized across 500+ Huawei devices, benefitting from
+        OpenJDK, is utilized across 500+ Huawei products, benefitting from
         the R&D team's extensive experience in addressing service-related
         challenges. As a downstream product of OpenJDK, it serves as a
         high-performance distribution for production environments,

--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -29,6 +29,24 @@ jdks {
       """
     },
     {
+      id = "bisheng"
+      vendor = "Huawei",
+      distribution = "Bisheng",
+      url = "https://bishengjdk.openeuler.org/"
+      description = """
+        Bisheng JDK is the open source version of Huawei's internal OpenJDK
+        customization Huawei JDK, a high-performance OpenJDK distribution that
+        can be used in production environments. Huawei JDK runs on more than
+        500 Huawei internal products, and has accumulated a large number of
+        usage scenarios and feedback from java developers, solving many problems
+        encountered in the actual operation of the business. With the performance
+        optimization on ARM architecture, Bisheng JDK can get better performance in
+        big data and other scenarios. Bisheng JDK currently supports Linux/AArch64
+        and Linux/x86_64 platforms. Bisheng JDK is also the downstream of OpenJDK,
+        and will continue to contribute to the OpenJDK community.
+      """
+    },
+    {
       id = "graal"
       vendor = "Oracle"
       distribution = "GraalVM"

--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -34,16 +34,16 @@ jdks {
       distribution = "Bisheng",
       url = "https://bishengjdk.openeuler.org/"
       description = """
-        Bisheng JDK is the open source version of Huawei's internal OpenJDK
-        customization Huawei JDK, a high-performance OpenJDK distribution that
-        can be used in production environments. Huawei JDK runs on more than
-        500 Huawei internal products, and has accumulated a large number of
-        usage scenarios and feedback from java developers, solving many problems
-        encountered in the actual operation of the business. With the performance
-        optimization on ARM architecture, Bisheng JDK can get better performance in
-        big data and other scenarios. Bisheng JDK currently supports Linux/AArch64
-        and Linux/x86_64 platforms. Bisheng JDK is also the downstream of OpenJDK,
-        and will continue to contribute to the OpenJDK community.
+        BiSheng JDK, an open-source adaptation of Huawei JDK derived from
+        OpenJDK, is utilized across 500+ Huawei devices, benefitting from
+        the R&D team's extensive experience in addressing service-related
+        challenges. As a downstream product of OpenJDK, it serves as a
+        high-performance distribution for production environments,
+        specifically addressing performance and stability issues in Huawei
+        applications. BiSheng JDK excels in optimizing ARM architecture
+        performance and stability, delivering enhanced results in big data
+        scenarios. Its primary goal is to offer Java developers a stable,
+        high-performance JDK, particularly excelling on the ARM architecture.
       """
     },
     {

--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -29,7 +29,7 @@ jdks {
       """
     },
     {
-      id = "bisheng"
+      id = "bsg"
       vendor = "Huawei",
       distribution = "Bisheng",
       url = "https://bishengjdk.openeuler.org/"


### PR DESCRIPTION
Bisheng JDK is the open source version of Huawei JDK, which is customized based on OpenJDK. Huawei JDK runs on more than 500 Huawei products, and the R&D team has accumulated rich development experience and solved a number of difficult problems encountered in the actual operation of the business.
Bisheng JDK, as the downstream of OpenJDK, is a high-performance OpenJDK distribution that can be used in production environments. Bisheng JDK fixes some performance and stability problems encountered in Huawei's internal application scenarios, and makes performance optimization and stability enhancement on ARM architecture, which is more stable on ARM architecture and can get better performance in big data and other scenarios.
Bisheng JDK is dedicated to provide JAVA developers with a stable, reliable, high-performance and easy-to-tune JDK, as well as a better choice for users on ARM architecture.
Currently there are 3 major versions, [8](https://gitee.com/openeuler/bishengjdk-8), [11](https://gitee.com/openeuler/bishengjdk-11) and [17](https://gitee.com/openeuler/bishengjdk-17).