### PR TITLE
Update the url for Tencent Kona JDK

### DIFF
--- a/conf/jdks.conf
+++ b/conf/jdks.conf
@@ -62,7 +62,7 @@ jdks {
       id = "kona"
       vendor = "Tencent"
       distribution = "Kona"
-      url = "https://github.com/Tencent/TencentKona-8"
+      url = "https://tencent.github.io/konajdk/"
       description = """
         Tencent Kona is a free, multi-platform, and production-ready distribution
         of OpenJDK, featuring Long-Term Support (LTS) releases. It serves as the


### PR DESCRIPTION
Just update the link to Tencent Kona JDK home page.
This new home page is: https://tencent.github.io/konajdk/