### PR TITLE
clarified instructions for mac

### DIFF
--- a/app/views/install.scala.html
+++ b/app/views/install.scala.html
@@ -13,9 +13,13 @@
                     Plus, it's compatible with both Bash and ZSH shells.</p>
                 <p>Just launch a new terminal and type in:</p>
                 <pre><code>$ curl -s "https://get.sdkman.io" | bash</code></pre>
-                <p>Follow the on-screen instructions to wrap up the installation. Afterward, open a new terminal or run
+                <p>Follow the on-screen instructions to wrap up the installation, they may diverge
+                    from system to system.</p>
+                <p>For example on Linux systems open a new terminal and run
                     the following in the same shell:</p>
                 <pre><code>$ source "$HOME/.sdkman/bin/sdkman-init.sh"</code></pre>
+                <p>And on Mac with homebrew, open a new terminal and run the following in the same shell:</p>
+                <pre><code>$ source "/opt/homebrew/opt/sdkman-cli/libexec/bin/sdkman-init.sh"</code></pre>
                 <p>Lastly, run the following snippet to confirm the installation's success:</p>
                 <pre><code>$ sdk version</code></pre>
                 <p>You should see output containing the latest script and native versions:</p>


### PR DESCRIPTION
While installing on Mac Sonoma, I've verified that the suggested sourcing script does not work. Instead, another source command is provided at the end of the installation process:

<img width="568" alt="sdkman instructions" src="https://github.com/sdkman/sdkman-website/assets/4623265/0b1acc06-a9f2-416f-a835-fce9358d6bd5">

Since this seems to be very system dependent, I believe that making it explicit would be a minor positive contribution to future users reading the documentation. At the end of the day, they should follow what's in the output of the installation script and not only the scripts that are provided there.

I have reworded to make it more explicit.