### PR TITLE
Add Discord icon in Socialise

### DIFF
--- a/app/views/includes/socialise.scala.html
+++ b/app/views/includes/socialise.scala.html
@@ -5,6 +5,10 @@
             <a href='https://slack.sdkman.io' class='icon'><span class='fa fa-slack'></span> Discuss in Slack</a>
         </li>
         <li>
+            <a href='https://discord.com/channels/sdkman' class='icon'><span class='fa fa-discord'></span> SDKMAN! on
+                Discord</a>
+        </li>
+        <li>
             <a href='https://twitter.com/sdkman_' class='icon'><span class='fa fa-twitter'></span> SDKMAN! on
                 Twitter</a>
         </li>

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,6 +1,8 @@
+// format: off
 // DO NOT EDIT! This file is auto-generated.
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.13")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.17")
 
+// format: on


### PR DESCRIPTION
- **Add button for discord**
- **Update metals descriptor**

For some reason, the new button just isn't showing up, and it's driving me nuts. Am I doing something obviously stupid? I've tried using existing icons, blowing away local caches, you name it.